### PR TITLE
Removed module by default, removed double include, updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Let's say you have a User model with a name, phone, and password.
 
 ##### Step 3: Change the validations to look like these:
 
-    validates :name, :presence => true, :unless => Proc.new { skip_name_validation? }
-    validates :phone, :presence => true, :unless => Proc.new { skip_phone_validation? }
-    validates :password, :presence => true, :unless => Proc.new { skip_pasword_validation? }
+    validates :name, :presence => true, :unless => Proc.new { |u| u.skip_name_validation? }
+    validates :phone, :presence => true, :unless => Proc.new { |u| u.skip_phone_validation? }
+    validates :password, :presence => true, :unless => Proc.new { |u| u.skip_pasword_validation? }
 
 ### In your controller:
 

--- a/README.md
+++ b/README.md
@@ -28,18 +28,22 @@ Let's say you have a User model with a name, phone, and password.
     validates :phone, :presence => true
     validates :password, :presence => true
 
-##### Step 1: Declare which validations are allowed to be skipped:
+##### Step 1: Include the ValidationSkipper module in the model:
+
+    include ValidationSkipper
+
+##### Step 2: Declare which validations are allowed to be skipped:
 
     can_skip_validation_for :name, :phone, :password
 
 (Note: this does not automatically skip them, but makes them eligible for skipping)
 
 
-##### Step 2: Change the validations to look like these:
+##### Step 3: Change the validations to look like these:
 
-    validates :name, :presence => true, :unless => skip_name_validation?
-    validates :phone, :presence => true, :unless => skip_phone_validation?
-    validates :password, :presence => true, :unless => skip_pasword_validation?
+    validates :name, :presence => true, :unless => Proc.new { skip_name_validation? }
+    validates :phone, :presence => true, :unless => Proc.new { skip_phone_validation? }
+    validates :password, :presence => true, :unless => Proc.new { skip_pasword_validation? }
 
 ### In your controller:
 

--- a/lib/validation_skipper.rb
+++ b/lib/validation_skipper.rb
@@ -13,16 +13,8 @@ module ValidationSkipper  # Creates "attr_accessor" methods and related boolean 
     end
   end
 
-  # Hook to include ClassMethods as... class methods.
-  def self.included(base)
-    base.extend ClassMethods
-  end
-
   # Defines a "skip_validation_for" method to use in controllers.
   def skip_validation_for(*args)
     args.each { |attr| send("skip_#{attr}_validation=", true) }
   end
 end
-
-# include the extension 
-ActiveRecord::Base.send(:include, ValidationSkipper)


### PR DESCRIPTION
This is going to appear like a very arrogant request which I promise is not the case.

Firstly I couldn't get the gem to work without wrapping `skip_attr_validation?` in a `Proc` like so, `Proc.new { skip_email_validation? }`. So my main motivation for forking was to update the documentation.

However it is entirely possible that I've not configured it possible and would appreciate your direction if this is the case.

Once forked, I noticed you were autoloading the module into the base model, something I wasn't terribly keen on (I should have separated this into a separate commit I realise). Regardless, I've updated the documentation to reflect this too.

Lastly, the `included` method appeared to be superfluous. But on reflection it might be there backwards compatibility.

Rich